### PR TITLE
Comments out dependencies that we don't need and haven't been approved by security

### DIFF
--- a/.github/workflows/sdk-publish.yaml
+++ b/.github/workflows/sdk-publish.yaml
@@ -622,13 +622,13 @@ jobs:
           repository: speakeasy-api/sdk-generation-action
           ref: d209f94c685eb681f61f8c4a478e5c0cf64a1ebc
           path: _speakeasy
-      - name: Publish
-        uses: speakeasy-api/packagist-update@5e2c88e23c7d21e40c7a02a3b252a749b351eb2f # support-github-creation
-        with:
-          username: ${{ secrets.packagist_username }}
-          api_token: ${{ secrets.packagist_token }}
-          repository_name: ${{ github.repository }}
-          repository_base_url: ${{ github.server_url }}
+      # - name: Publish
+      #   uses: speakeasy-api/packagist-update@5e2c88e23c7d21e40c7a02a3b252a749b351eb2f # support-github-creation
+      #   with:
+      #     username: ${{ secrets.packagist_username }}
+      #     api_token: ${{ secrets.packagist_token }}
+      #     repository_name: ${{ github.repository }}
+      #     repository_base_url: ${{ github.server_url }}
       - id: publish-event
         uses: ./_speakeasy
         if: always()

--- a/.github/workflows/workflow-executor.yaml
+++ b/.github/workflows/workflow-executor.yaml
@@ -729,13 +729,13 @@ jobs:
           repository: speakeasy-api/sdk-generation-action
           ref: d209f94c685eb681f61f8c4a478e5c0cf64a1ebc
           path: _speakeasy
-      - name: Publish
-        uses: speakeasy-api/packagist-update@5e2c88e23c7d21e40c7a02a3b252a749b351eb2f # support-github-creation
-        with:
-          username: ${{ secrets.packagist_username }}
-          api_token: ${{ secrets.packagist_token }}
-          repository_name: ${{ github.repository }}
-          repository_base_url: ${{ github.server_url }}
+      # - name: Publish
+      #   uses: speakeasy-api/packagist-update@5e2c88e23c7d21e40c7a02a3b252a749b351eb2f # support-github-creation
+      #   with:
+      #     username: ${{ secrets.packagist_username }}
+      #     api_token: ${{ secrets.packagist_token }}
+      #     repository_name: ${{ github.repository }}
+      #     repository_base_url: ${{ github.server_url }}
       - id: publish-event
         uses: ./_speakeasy
         if: always()


### PR DESCRIPTION
In the same vein as the change made here https://github.com/speakeasy-api/sdk-generation-action/commit/e9f0f54bc50523ba5120ce0a909564c391eda899, we can comment out these dependencies to unblock the job from being able to run, because we do not actually use the PHP pipeline.